### PR TITLE
Payments request method now also confirms the payment requested

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const fs = require('fs');
 const yaml = require('js-yaml');
 const uuid = require('node-uuid');

--- a/index.js
+++ b/index.js
@@ -25,10 +25,6 @@ app.use(morgan('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
-// uncomment after placing your favicon in /public
-// app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
-// not using express less
-// app.use(require('less-middleware')(path.join(__dirname, 'server/public')));
 app.use(express.static(path.join(__dirname, './server/public')));
 
 // memory based session
@@ -43,7 +39,7 @@ app.use(session({
 app.use(`/api/v${apiVersion}/payment*`, genTransactionPassword);
 
 // get an instance of the router for api routes
-const router = express.Router();
+const router = express.Router(); // eslint-disable-line new-cap
 app.use(`/api/v${apiVersion}`, routes(router));
 
 app.all('/*', (req, res) => {
@@ -60,7 +56,7 @@ app.use((req, res, next) => {
 // error handlers
 app.use((err, req, res, next) => {
   if (typeof err === 'undefined') next();
-  console.log('An error occured: ', err.message);
+  console.error('An error occured: ', err.message); // eslint-disable-line no-console
   const errorResponse = {
     status_code: err.statusCode,
     request_url: req.originalUrl,
@@ -80,9 +76,8 @@ app.use((err, req, res, next) => {
 });
 
 const server = app.listen(process.env.PORT || 8080, () => {
-  console.log('Your secret session key is: ' + process.env.SESSION_SECRET_KEY);
-  console.log('Express server listening on %d, in %s' +
-    ' mode', server.address().port, app.get('env'));
+  console.log('Your secret session key is: ' + process.env.SESSION_SECRET_KEY); // eslint-disable-line no-console
+  console.log('Express server listening on %d, in %s mode', server.address().port, app.get('env')); // eslint-disable-line no-console
 });
 
 // expose app

--- a/index.js
+++ b/index.js
@@ -43,15 +43,12 @@ app.use(session({
 app.use(`/api/v${apiVersion}/payment*`, genTransactionPassword);
 
 // get an instance of the router for api routes
-const apiRouter = express.Router;
-app.use(`/api/v${apiVersion}`, routes(apiRouter()));
+const router = express.Router();
+app.use(`/api/v${apiVersion}`, routes(router));
 
 app.all('/*', (req, res) => {
   res.render('index', { title: 'Project Mulla' });
 });
-
-// use this prettify the error stack string into an array of stack traces
-const prettifyStackTrace = stackTrace => stackTrace.replace(/\s{2,}/g, ' ').trim();
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {
@@ -69,6 +66,9 @@ app.use((err, req, res, next) => {
     request_url: req.originalUrl,
     message: err.message,
   };
+
+  // use this prettify the error stack string into an array of stack traces
+  const prettifyStackTrace = stackTrace => stackTrace.replace(/\s{2,}/g, ' ').trim();
 
   // Only send back the error stack if it's on development mode
   if (process.env.NODE_ENV === 'development') {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "develop": "nodemon -w ./server -w index.js -w environment.js --exec npm start",
     "lint": "eslint --fix ./server ./test",
     "monitor": "nodemon index.js",
-    "start": "node index.js",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -37,8 +35,7 @@
     "morgan": "~1.6.1",
     "node-uuid": "^1.4.7",
     "request": "^2.72.0",
-    "serve-favicon": "~2.3.0",
-    "snyk": "^1.18.0"
+    "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
@@ -63,6 +60,5 @@
   "engines": {
     "node": "^4.3.2",
     "npm": "^3.9.5"
-  },
-  "snyk": true
+  }
 }

--- a/server/controllers/ConfirmPayment.js
+++ b/server/controllers/ConfirmPayment.js
@@ -2,7 +2,6 @@
 
 const ParseResponse = require('../utils/ParseResponse');
 const SOAPRequest = require('../utils/SOAPRequest');
-const responseError = require('../utils/errors/responseError');
 
 const parseResponse = new ParseResponse('transactionconfirmresponse');
 const soapRequest = new SOAPRequest();
@@ -36,19 +35,17 @@ class ConfirmPayment {
     return this;
   }
 
-  handler(req, res) {
+  handler(params) {
     const paymentDetails = {
-      transactionID: req.params.id, // eg. '99d0b1c0237b70f3dc63f36232b9984c'
-      timeStamp: req.timeStamp,
-      encryptedPassword: req.encryptedPassword,
+      transactionID: params.transactionID, // eg. '99d0b1c0237b70f3dc63f36232b9984c'
+      timeStamp: params.timeStamp,
+      encryptedPassword: params.encryptedPassword,
     };
     const payment = this.buildSoapBody(paymentDetails);
     const confirm = this.soapRequest.construct(payment, this.parser);
 
     // process ConfirmPayment response
-    return confirm.post()
-      .then(response => res.status(200).json({ response }))
-      .catch(error => responseError(error, res));
+    return confirm.post();
   }
 }
 

--- a/server/controllers/PaymentRequest.js
+++ b/server/controllers/PaymentRequest.js
@@ -87,7 +87,10 @@ class PaymentRequest {
         };
         return ConfirmPayment.handler(params);
       })
-      .then(() => res.status(200).json(finalResponse))
+      .then((response) => {
+        Object.assign(finalResponse.response, response);
+        return res.status(200).json(finalResponse);
+      })
       .catch(error => responseError(error, res));
   }
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,11 +11,8 @@ module.exports = (router) => {
   // check the status of the API system
   router.get('/status', (req, res) => res.json({ status: 200 }));
 
-  router.post(
-    '/payment/request',
-    checkForRequiredParams,
-    (req, res) => PaymentRequest.handler(req, res)
-  );
+  const requestPaymentHandler = (req, res) => PaymentRequest.handler(req, res);
+  router.post('/payment/request', checkForRequiredParams, requestPaymentHandler);
   router.get('/payment/confirm/:id', (req, res) => ConfirmPayment.handler(req, res));
   router.get('/payment/status/:id', (req, res) => PaymentStatus.handler(req, res));
   router.all('/payment/success', (req, res) => PaymentSuccess.handler(req, res));

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,19 +1,18 @@
 'use strict';
 
 const PaymentRequest = require('../controllers/PaymentRequest');
-const ConfirmPayment = require('../controllers/ConfirmPayment');
 const PaymentStatus = require('../controllers/PaymentStatus');
 const PaymentSuccess = require('../controllers/PaymentSuccess');
 const checkForRequiredParams = require('../validators/checkForRequiredParams');
 
 
 module.exports = (router) => {
+  const paymentRequestHandler = (req, res) => PaymentRequest.handler(req, res);
+
   // check the status of the API system
   router.get('/status', (req, res) => res.json({ status: 200 }));
 
-  const requestPaymentHandler = (req, res) => PaymentRequest.handler(req, res);
-  router.post('/payment/request', checkForRequiredParams, requestPaymentHandler);
-  router.get('/payment/confirm/:id', (req, res) => ConfirmPayment.handler(req, res));
+  router.post('/payment/request', checkForRequiredParams, paymentRequestHandler);
   router.get('/payment/status/:id', (req, res) => PaymentStatus.handler(req, res));
   router.all('/payment/success', (req, res) => PaymentSuccess.handler(req, res));
 

--- a/server/utils/GenEncryptedPassword.js
+++ b/server/utils/GenEncryptedPassword.js
@@ -1,6 +1,6 @@
 'use strict';
-const crypto = require('crypto');
 
+const crypto = require('crypto');
 
 module.exports = class GenEncryptedPassword {
   constructor(timeStamp) {

--- a/server/utils/ParseResponse.js
+++ b/server/utils/ParseResponse.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const cheerio = require('cheerio');
 const statusCodes = require('../config/statusCodes');
 

--- a/server/utils/genTransactionPassword.js
+++ b/server/utils/genTransactionPassword.js
@@ -1,7 +1,7 @@
 'use strict';
+
 const moment = require('moment');
 const GenEncryptedPassword = require('./GenEncryptedPassword');
-
 
 const genTransactionPassword = (req, res, next) => {
   req.timeStamp = moment().format('YYYYMMDDHHmmss'); // In PHP => "YmdHis"

--- a/test/controllers/ConfirmPayment.js
+++ b/test/controllers/ConfirmPayment.js
@@ -45,6 +45,11 @@ describe('confirmPayment', () => {
     return promise;
   });
 
+  beforeEach(() => {
+    promise.then.reset();
+    promise.catch.reset();
+  });
+
   confirmPayment.parser = sinon.stub().returnsThis();
   confirmPayment.soapRequest.construct = sinon.stub().returnsThis();
   confirmPayment.soapRequest.post = sinon.stub().returns(promise);
@@ -71,21 +76,14 @@ describe('confirmPayment', () => {
 
   it('Makes a SOAP request and returns a promise', () => {
     confirmPayment.buildSoapBody = sinon.stub();
+    // const confirmPaymentHandler = sinon.spy(confirmPayment, 'handler');
     confirmPayment.handler(req, res);
 
     assert.isTrue(confirmPayment.buildSoapBody.called);
     assert.isTrue(confirmPayment.soapRequest.construct.called);
     assert.isTrue(confirmPayment.soapRequest.post.called);
 
-    assert.isTrue(promise.then.called);
-    assert.isTrue(promise.catch.called);
-    assert.isTrue(res.status.calledWithExactly(200));
-    assert.isTrue(res.json.called);
-
-    const spyCall = res.json.getCall(0);
-    assert.isObject(spyCall.args[0]);
-    assert.sameMembers(Object.keys(spyCall.args[0].response), [
-      'status_code',
-    ]);
+    assert.isFalse(promise.then.called);
+    assert.isFalse(promise.catch.called);
   });
 });

--- a/test/controllers/PaymentRequest.js
+++ b/test/controllers/PaymentRequest.js
@@ -8,7 +8,10 @@ const moment = require('moment');
 const uuid = require('node-uuid');
 
 const paymentRequest = require('../../server/controllers/PaymentRequest');
+const confirmPayment = require('../../server/controllers/ConfirmPayment');
 const GenEncryptedPassword = require('../../server/utils/GenEncryptedPassword');
+
+process.env.API_VERSION = '1';
 
 describe('paymentRequest', () => {
   const timeStamp = moment().format('YYYYMMDDHHmmss');
@@ -24,6 +27,8 @@ describe('paymentRequest', () => {
   };
 
   const req = {};
+  req.protocol = 'https';
+  req.hostname = 'sillyhostname.com';
   req.timeStamp = timeStamp;
   req.encryptedPassword = encryptedPassword;
   req.body = {
@@ -37,9 +42,7 @@ describe('paymentRequest', () => {
   res.json = sinon.stub();
 
   const response = { status_code: 200 };
-  const promise = new Promise((resolve) => {
-    resolve(response);
-  });
+  const promise = new Promise((resolve) => { resolve(response); });
 
   sinon.stub(promise, 'then', (callback) => {
     callback(response);
@@ -51,9 +54,18 @@ describe('paymentRequest', () => {
     return promise;
   });
 
+  beforeEach(() => {
+    promise.then.reset();
+    promise.catch.reset();
+  });
+
   paymentRequest.parser = sinon.stub().returnsThis();
   paymentRequest.soapRequest.construct = sinon.stub().returnsThis();
   paymentRequest.soapRequest.post = sinon.stub().returns(promise);
+
+  confirmPayment.parser = sinon.stub().returnsThis();
+  confirmPayment.soapRequest.construct = sinon.stub().returnsThis();
+  confirmPayment.soapRequest.post = sinon.stub().returns(promise);
 
   it('BuildSoapBody builds the soap body string', () => {
     paymentRequest.buildSoapBody(params);
@@ -63,6 +75,7 @@ describe('paymentRequest', () => {
   });
 
   it('Makes a SOAP request and returns a promise', () => {
+    sinon.spy(confirmPayment, 'handler');
     paymentRequest.buildSoapBody = sinon.stub();
     paymentRequest.handler(req, res);
 
@@ -70,10 +83,13 @@ describe('paymentRequest', () => {
     assert.isTrue(paymentRequest.soapRequest.construct.called);
     assert.isTrue(paymentRequest.soapRequest.post.called);
 
-    assert.isTrue(promise.then.called);
+    assert.isTrue(confirmPayment.buildSoapBody.called);
+    assert.isTrue(confirmPayment.soapRequest.construct.called);
+    assert.isTrue(confirmPayment.soapRequest.post.called);
+
+    assert.isTrue(promise.then.calledTwice);
+    assert.isTrue(confirmPayment.handler.calledOnce);
     assert.isTrue(promise.catch.called);
-    assert.isTrue(res.status.calledWithExactly(200));
-    assert.isTrue(res.json.called);
 
     const spyCall = res.json.getCall(0);
     assert.isObject(spyCall.args[0]);

--- a/test/controllers/PaymentRequest.js
+++ b/test/controllers/PaymentRequest.js
@@ -28,7 +28,7 @@ describe('paymentRequest', () => {
 
   const req = {};
   req.protocol = 'https';
-  req.hostname = 'sillyhostname.com';
+  req.hostname = 'projectmullahostname.com';
   req.timeStamp = timeStamp;
   req.encryptedPassword = encryptedPassword;
   req.body = {
@@ -93,7 +93,8 @@ describe('paymentRequest', () => {
 
     const spyCall = res.json.getCall(0);
     assert.isObject(spyCall.args[0]);
-    assert.sameMembers(Object.keys(spyCall.args[0].response), [
+    console.log(spyCall.args[0]);
+    assert.includeMembers(Object.keys(spyCall.args[0].response), [
       'status_code',
       'reference_id',
       'merchant_transaction_id',

--- a/test/controllers/PaymentSuccess.js
+++ b/test/controllers/PaymentSuccess.js
@@ -3,7 +3,6 @@
 require('../../environment');
 const chai = require('chai');
 const assert = chai.assert;
-const expect = chai.expect;
 const sinon = require('sinon');
 
 const paymentSuccess = require('../../server/controllers/PaymentSuccess');
@@ -66,7 +65,7 @@ describe('paymentSuccess', () => {
       'status_code',
       'trx_id',
       'trx_status',
-      'username'
+      'username',
     ]);
   });
 
@@ -75,7 +74,6 @@ describe('paymentSuccess', () => {
     process.env.NODE_ENV = 'production';
     paymentSuccess.handler(req, res, next);
 
-    console.log(next.args);
     const spyCall = next.getCall(0);
     const args = spyCall.args[0];
 


### PR DESCRIPTION
### What does this PR change?

When one now pings the endpoint `/payment/request` it initializes the payment and on response confirms the payment by also hitting the endpoint `payment/confirm`

This means you no longer have to make a second call to Project Mulla to confirm the payment thus hitting up the user's phone with the USSD prompt. One call to `payment/request` should handle this automatically.


### To Do:
- Update README accordingly
- Update documentation accordingly
